### PR TITLE
Update to use pytests to match readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For a completed example that uses this template, see [https://github.com/bytewax
 ### Development
 
 This template includes an optional set of development dependencies which can be
-installed with `pip install .[dev]`.
+installed with `pip install .[dev]`. _If you get an error using `zsh` you may need to quote the path like this - `pip install '.[dev]'`_
 
 This template also contains a configuration for using
 [pre-commit](https://pre-commit.com/) hooks. You can install the pre-commit

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,12 +1,21 @@
-import unittest
-
-# from sample.sample_input_connector import SampleInput
-
-
-class TestSimple(unittest.TestCase):
-    def test_add_one(self):
-        self.assertEqual(5 + 1, 6)
+from bytewax.dataflow import Dataflow
+from bytewax.testing import run_main, TestingInput, TestingOutput
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_map():
+    flow = Dataflow()
+
+    inp = [0, 1, 2]
+    flow.input("inp", TestingInput(inp))
+
+    def add_one(item):
+        return item + 1
+
+    flow.map(add_one)
+
+    out = []
+    flow.output("out", TestingOutput(out))
+
+    run_main(flow)
+
+    assert sorted(out) == sorted([1, 2, 3])


### PR DESCRIPTION
Move from unittest example to pytests example to match the README and our own tests in `bytewax/bytewax`.